### PR TITLE
Fix missing include

### DIFF
--- a/Engine/Source/Editor/EditorImgui.h
+++ b/Engine/Source/Editor/EditorImgui.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #if EDITOR
-
+#include <cstdint>
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
 


### PR DESCRIPTION
This pull request simply adds the missing include in `Engine/Source/Editor/EditorImgui.h`, as described in Issue #8. I tested the fix and it compiles.