### PR TITLE
Output of compile.bat better readability

### DIFF
--- a/Engine/Shaders/GLSL/compile.bat
+++ b/Engine/Shaders/GLSL/compile.bat
@@ -1,8 +1,9 @@
+@echo off
 if not exist ".\bin" mkdir .\bin
 
 for %%f in (.\src\*) do (
-
-  echo %%~xf
+  echo:
+  echo %%~nxf
   
   if NOT "%%~xf" == ".glsl" (
     (( %VULKAN_SDK%/Bin/glslc.exe %%f -O -g -fpreserve-bindings -o .\bin\%%~nxf ) && ( echo Compile Successful )) || pause 


### PR DESCRIPTION
Ultimately a nitpicky change but it helps understand what is happening.

Disable command echo, apply a new line and list the whole file name

Output example:

```
Forward.frag
Compile Successful

Forward.vert
Compile Successful

ForwardColor.vert
Compile Successful
...
```