### PR TITLE
fix errors when building zlib on debian

### DIFF
--- a/External/Zlib/gzguts.h
+++ b/External/Zlib/gzguts.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <stdio.h>
+#include <unistd.h>
 #include "zlib.h"
 #ifdef STDC
 #  include <string.h>


### PR DESCRIPTION
incliding unistd.h fixes errors when building gzlib, gzread, and gzwrite on debian