### PR TITLE
Prevent Crash When an Invalid Folder Is Selected

### DIFF
--- a/Engine/Source/Editor/ActionManager.cpp
+++ b/Engine/Source/Editor/ActionManager.cpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <functional>
 #include <algorithm>
-#include <filesystem>
 
 #include "Log.h"
 #include "EditorConstants.h"
@@ -1162,7 +1161,7 @@ void ActionManager::CreateNewProject(const char* folderPath, bool cpp)
 
         LogDebug("CreateNewProject: %s @ %s", newProjName.c_str(), newProjDir.c_str());
         {
-            if (!std::filesystem::exists(newProjDir))
+            if (!DoesDirExist(newProjDir.c_str()))
             {
                 LogDebug("The specified folder was not found, it will now be created @ %s",newProjDir.c_str());
                 SYS_CreateDirectory(newProjDir.c_str());

--- a/Engine/Source/Editor/ActionManager.cpp
+++ b/Engine/Source/Editor/ActionManager.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <functional>
 #include <algorithm>
+#include <filesystem>
 
 #include "Log.h"
 #include "EditorConstants.h"
@@ -1160,6 +1161,13 @@ void ActionManager::CreateNewProject(const char* folderPath, bool cpp)
         }
 
         LogDebug("CreateNewProject: %s @ %s", newProjName.c_str(), newProjDir.c_str());
+        {
+            if (!std::filesystem::exists(newProjDir))
+            {
+                LogDebug("The specified folder was not found, it will now be created @ %s",newProjDir.c_str());
+                SYS_CreateDirectory(newProjDir.c_str());
+            }
+        }
 
         newProjDir += "/";
 


### PR DESCRIPTION
When creating a new folder using ImGui, it's possible for the user to select a folder that doesn't exist which causes a crash. I tested the changes and they compiled and function as intended.