### PR TITLE
3DS Gyroscope/Accelerometer Input

### DIFF
--- a/Documentation/Lua/Systems/Input.md
+++ b/Documentation/Lua/Systems/Input.md
@@ -199,6 +199,20 @@ Sig: `value = Input.GetGamepadAxis(axis, index=1)`
  - Arg: `integer index` Gamepad index/port
  - Ret: `number value` Axis value (0 to 1)
 ---
+### GetGamepadGyro
+Get a vector containing the x,y,z values of your gamepads gyroscope. Currently only supported on the 3DS.
+
+Sig: `value = Input.GetGamepadGyro(index=1)`
+ - Arg: `integer index` Gamepad index/port
+ - Ret: `Vector value` Gyroscope vector
+---
+### GetGamepadAcceleration
+Get a vector containing the x,y,z values of your gamepads accelerometer. Currently only supported on the 3DS.
+
+Sig: `value = Input.GetGamepadAcceleration(index=1)`
+ - Arg: `integer index` Gamepad index/port
+ - Ret: `Vector value` Accelerometer vector
+---
 ### GetGamepadType
 Check what type of gamepad is connected. This is really only useful on Wii where you might have a Wiimote, Wii classic, or GameCube controller.
 

--- a/Engine/Source/Input/3DS/Input_3DS.cpp
+++ b/Engine/Source/Input/3DS/Input_3DS.cpp
@@ -18,11 +18,19 @@ void INP_Initialize()
     InputInit();
 
     irrstInit();
+
+    // Initialize accelerometer and gyroscope
+    HIDUSER_EnableAccelerometer();
+    HIDUSER_EnableGyroscope();
 }
 
 void INP_Shutdown()
 {
     irrstExit();
+
+    // Disable accelerometer and gyroscope
+    HIDUSER_DisableAccelerometer();
+    HIDUSER_DisableGyroscope();
 
     InputShutdown();
 }
@@ -74,6 +82,26 @@ void INP_Update()
 
     input.mGamepads[0].mAxes[GAMEPAD_AXIS_RTHUMB_X] = glm::clamp(rsPos.dx / 145.0f, -1.0f, 1.0f);
     input.mGamepads[0].mAxes[GAMEPAD_AXIS_RTHUMB_Y] = glm::clamp(rsPos.dy / 145.0f, -1.0f, 1.0f);
+
+    // Accelerometer
+    accelVector accel;
+    hidAccelRead(&accel);
+
+    // Convert from s16 to normalized float (-1.0f to 1.0f)
+    const float ACCEL_SCALE = 1.0f / 512.0f; // Approximate normalization factor
+    input.mGamepads[0].mAccel[0] = accel.x * ACCEL_SCALE;
+    input.mGamepads[0].mAccel[1] = accel.y * ACCEL_SCALE;
+    input.mGamepads[0].mAccel[2] = accel.z * ACCEL_SCALE;
+
+    // Gyroscope
+    angularRate gyro;
+    hidGyroRead(&gyro);
+
+    // Convert from s16 to normalized float (-1.0f to 1.0f)
+    const float GYRO_SCALE = 1.0f / 1024.0f; // Approximate normalization factor
+    input.mGamepads[0].mGyro[0] = gyro.x * GYRO_SCALE;
+    input.mGamepads[0].mGyro[1] = gyro.y * GYRO_SCALE;
+    input.mGamepads[0].mGyro[2] = gyro.z * GYRO_SCALE;
 
     // Touch
     if (down & KEY_TOUCH)

--- a/Engine/Source/Input/Input.cpp
+++ b/Engine/Source/Input/Input.cpp
@@ -279,7 +279,7 @@ void INP_ClearTouch(int32_t touch)
         for (uint32_t i = touch; i < INPUT_MAX_TOUCHES; ++i)
         {
             if (i < INPUT_MAX_TOUCHES - 1 &&
-                input.mTouches[i+1])
+                input.mTouches[i + 1])
             {
                 input.mTouches[i] = input.mTouches[i + 1];
                 input.mPointerX[i] = input.mPointerX[i + 1];
@@ -551,6 +551,36 @@ void INP_ClearGamepadButton(GamepadButtonCode buttonCode, int32_t gamepadIndex)
     {
         InputState& input = GetEngineState()->mInput;
         input.mGamepads[gamepadIndex].mButtons[(int32_t)buttonCode] = 0;
+    }
+}
+
+void INP_GetGamepadGyro(float& x, float& y, float& z, int32_t gamepadIndex)
+{
+    if (gamepadIndex >= 0 && gamepadIndex < INPUT_MAX_GAMEPADS)
+    {
+        InputState& input = GetEngineState()->mInput;
+        x = input.mGamepads[gamepadIndex].mGyro[0];
+        y = input.mGamepads[gamepadIndex].mGyro[1];
+        z = input.mGamepads[gamepadIndex].mGyro[2];
+    }
+    else
+    {
+        x = y = z = 0.0f;
+    }
+}
+
+void INP_GetGamepadAcceleration(float& x, float& y, float& z, int32_t gamepadIndex)
+{
+    if (gamepadIndex >= 0 && gamepadIndex < INPUT_MAX_GAMEPADS)
+    {
+        InputState& input = GetEngineState()->mInput;
+        x = input.mGamepads[gamepadIndex].mAccel[0];
+        y = input.mGamepads[gamepadIndex].mAccel[1];
+        z = input.mGamepads[gamepadIndex].mAccel[2];
+    }
+    else
+    {
+        x = y = z = 0.0f;
     }
 }
 

--- a/Engine/Source/Input/Input.h
+++ b/Engine/Source/Input/Input.h
@@ -61,6 +61,8 @@ int32_t INP_GetGamepadIndex(int32_t inputDevice);
 void INP_SetGamepadAxisValue(GamepadAxisCode axisCode, float axisValue, int32_t gamepadIndex);
 void INP_SetGamepadButton(GamepadButtonCode buttonCode, int32_t gamepadIndex);
 void INP_ClearGamepadButton(GamepadButtonCode buttonCode, int32_t gamepadIndex);
+void INP_GetGamepadGyro(float& x, float& y, float& z, int32_t gamepadIndex);
+void INP_GetGamepadAcceleration(float& x, float& y, float& z, int32_t gamepadIndex);
 
 bool INP_IsCursorLocked();
 bool INP_IsCursorTrapped();

--- a/Engine/Source/Input/InputTypes.h
+++ b/Engine/Source/Input/InputTypes.h
@@ -87,6 +87,8 @@ struct GamepadState
     int32_t mDevice = -1;
     int32_t mButtons[GAMEPAD_BUTTON_COUNT] = { };
     float mAxes[GAMEPAD_AXIS_COUNT] = { };
+    float mAccel[3] = { }; // x, y, z accelerometer values
+    float mGyro[3] = { };  // x, y, z gyroscope values
     GamepadType mType = GamepadType::Standard;
     bool mConnected = false;
 };

--- a/Engine/Source/LuaBindings/Input_Lua.cpp
+++ b/Engine/Source/LuaBindings/Input_Lua.cpp
@@ -1,6 +1,7 @@
 #include "LuaBindings/Input_Lua.h"
 #include "LuaBindings/Signal_Lua.h"
 #include "LuaBindings/Node_Lua.h"
+#include "LuaBindings/Vector_Lua.h"
 
 #include "InputDevices.h"
 #include "Input/Input.h"
@@ -277,7 +278,7 @@ int Input_Lua::GetGamepadAxisValue(lua_State* L)
 
 int Input_Lua::GetGamepadType(lua_State* L)
 {
-    int index = lua_isinteger(L, 1) ? lua_tointeger(L, 1) - 1: 0;
+    int index = lua_isinteger(L, 1) ? lua_tointeger(L, 1) - 1 : 0;
 
     GamepadType padType = ::GetGamepadType(index);
 
@@ -316,6 +317,34 @@ int Input_Lua::IsGamepadConnected(lua_State* L)
     return 1;
 }
 
+int Input_Lua::GetGamepadGyro(lua_State* L)
+{
+    int index = lua_isinteger(L, 1) ? lua_tointeger(L, 1) - 1 : 0;
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+
+    INP_GetGamepadGyro(x, y, z, index);
+
+    // Create a Vector object with the gyro data
+    return Vector_Lua::Create(L, glm::vec3(x, y, z));
+}
+
+int Input_Lua::GetGamepadAcceleration(lua_State* L)
+{
+    int index = lua_isinteger(L, 1) ? lua_tointeger(L, 1) - 1 : 0;
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+
+    INP_GetGamepadAcceleration(x, y, z, index);
+
+    // Create a Vector object with the acceleration data
+    return Vector_Lua::Create(L, glm::vec3(x, y, z));
+}
+
 int Input_Lua::ShowCursor(lua_State* L)
 {
     bool show = CHECK_BOOLEAN(L, 1);
@@ -337,8 +366,8 @@ int Input_Lua::SetCursorPosition(lua_State* L)
 
 int Input_Lua::GetKeysJustDown(lua_State* L)
 {
-     LuaPushDatum(L, GetEngineState()->mInput.mJustDownKeys);
-     return 1;
+    LuaPushDatum(L, GetEngineState()->mInput.mJustDownKeys);
+    return 1;
 }
 
 int Input_Lua::IsAnyKeyJustDown(lua_State* L)
@@ -459,6 +488,10 @@ void Input_Lua::Bind()
     REGISTER_TABLE_FUNC(L, tableIdx, GetGamepadType);
 
     REGISTER_TABLE_FUNC(L, tableIdx, IsGamepadConnected);
+
+    REGISTER_TABLE_FUNC(L, tableIdx, GetGamepadGyro);
+
+    REGISTER_TABLE_FUNC(L, tableIdx, GetGamepadAcceleration);
 
     REGISTER_TABLE_FUNC(L, tableIdx, ShowCursor);
 

--- a/Engine/Source/LuaBindings/Input_Lua.h
+++ b/Engine/Source/LuaBindings/Input_Lua.h
@@ -44,6 +44,8 @@ struct Input_Lua
     static int GetGamepadAxisValue(lua_State* L);
     static int GetGamepadType(lua_State* L);
     static int IsGamepadConnected(lua_State* L);
+    static int GetGamepadGyro(lua_State* L);
+    static int GetGamepadAcceleration(lua_State* L);
 
     static int ShowCursor(lua_State* L);
     static int SetCursorPosition(lua_State* L);


### PR DESCRIPTION
I wanted gyro input for my 3DS project so here it is. I was going to try adding support for dolphin/other platforms as well but didn't want to get ahead of myself (and the dolphin export isn't working for me as I have the latest devkitpro install 😅)

# Implementation

Here's a basic example:

```lua
local gyro = Input.GetGamepadGyro()
self.camera:SetWorldRotation(self.camera:GetWorldRotation() + gyro * self.sensitivity)
```

### GetGamepadGyro
Get a vector containing the x,y,z values of your gamepads gyroscope. Currently only supported on the 3DS.

Sig: `value = Input.GetGamepadGyro(index=1)`
 - Arg: `integer index` Gamepad index/port
 - Ret: `Vector value` Gyroscope vector
---
### GetGamepadAcceleration
Get a vector containing the x,y,z values of your gamepads accelerometer. Currently only supported on the 3DS.

Sig: `value = Input.GetGamepadAcceleration(index=1)`
 - Arg: `integer index` Gamepad index/port
 - Ret: `Vector value` Accelerometer vector
---

I decided to give gyro and acceleration their own dedicated functions that return Vectors instead of using `GetGamepadAxis()` since you'll want to be using these values as Vectors most times anyway. Maybe I could have the dedicated function AND each of the individual axis? Let me know what you think.

https://github.com/user-attachments/assets/76b49e07-6811-4e16-8773-1fe16b1169da

###### This video may seem like it has a bit of delay between input/output, but it's just because I apply some camera smoothing

