### PR TITLE
Editor Hot-Reloading

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -648,6 +648,7 @@
     <ClCompile Include="Source\Engine\Datum.cpp" />
     <ClCompile Include="Source\Engine\Engine.cpp" />
     <ClCompile Include="Source\Engine\EngineTypes.cpp" />
+    <ClCompile Include="Source\Engine\FileWatcher.cpp" />
     <ClCompile Include="Source\Engine\CameraFrustum.cpp" />
     <ClCompile Include="Source\Engine\InputDevices.cpp" />
     <ClCompile Include="Source\Engine\Log.cpp" />
@@ -888,6 +889,7 @@
     <ClInclude Include="Source\Engine\EngineTypes.h" />
     <ClInclude Include="Source\Engine\Enums.h" />
     <ClInclude Include="Source\Engine\Factory.h" />
+    <ClInclude Include="Source\Engine\FileWatcher.h" />
     <ClInclude Include="Source\Engine\InputDevices.h" />
     <ClInclude Include="Source\Engine\Line.h" />
     <ClInclude Include="Source\Engine\Log.h" />

--- a/Engine/Source/Editor/EditorImgui.cpp
+++ b/Engine/Source/Editor/EditorImgui.cpp
@@ -2957,6 +2957,13 @@ static void DrawViewportPanel()
             am->ResaveAllAssets();
         if (ImGui::Selectable("Reload All Scripts"))
             ReloadAllScripts();
+        
+        // Script Hot-Reload toggle
+        bool hotReloadEnabled = IsScriptHotReloadEnabled();
+        std::string hotReloadText = hotReloadEnabled ? "Disable Script Hot-Reload" : "Enable Script Hot-Reload";
+        if (ImGui::Selectable(hotReloadText.c_str()))
+            SetScriptHotReloadEnabled(!hotReloadEnabled);
+        
         if (ImGui::Selectable("Write Config"))
             WriteEngineConfig();
         //if (ImGui::Selectable("Import Scene"))

--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -18,6 +18,8 @@
 #include "ScriptFunc.h"
 #include "TimerManager.h"
 #include "Nodes/Widgets/Button.h"
+#include "FileWatcher.h"
+#include "ScriptUtils.h"
 
 #include "System/System.h"
 #include "Graphics/Graphics.h"
@@ -48,6 +50,38 @@ static EngineConfig sEngineConfig;
 
 static std::vector<World*> sWorlds;
 static Clock sClock;
+
+// File watcher callback for script hot-reloading
+void OnScriptFileChanged(const FileChangeEvent& event)
+{
+    if (event.action == FileAction::Modified || event.action == FileAction::Added)
+    {
+        // Get relative path from project directory
+        std::string projectDir = GetEngineState()->mProjectDirectory;
+        std::string scriptDir = projectDir + "Scripts/";
+
+        if (event.filePath.find(scriptDir) == 0)
+        {
+            // Extract relative script path
+            std::string relativePath = event.filePath.substr(scriptDir.length());
+            
+            // Replace backslashes with forward slashes for consistency
+            for (size_t i = 0; i < relativePath.length(); ++i)
+            {
+                if (relativePath[i] == '\\')
+                {
+                    relativePath[i] = '/';
+                }
+            }
+            
+            // Reload the specific script file
+            if (!ScriptUtils::ReloadScriptFile(relativePath))
+            {
+                LogWarning("Failed to hot-reload script: %s", relativePath.c_str());
+            }
+        }
+    }
+}
 
 void ForceLinkage()
 {
@@ -267,6 +301,16 @@ bool Initialize()
     renderer->Initialize();
     NetworkManager::Get()->Initialize();
 
+#if EDITOR
+    // Initialize FileWatcher for script hot-reloading
+    CreateFileWatcher();
+    if (GetFileWatcher())
+    {
+        GetFileWatcher()->Initialize();
+        GetFileWatcher()->SetFileChangeCallback(OnScriptFileChanged);
+    }
+#endif
+
     sClock.Start();
 
     sWorlds.push_back(new World());
@@ -368,6 +412,14 @@ bool Update()
     lua_State* L = GetLua();
     lua_settop(L, 0);
 
+#if EDITOR
+    // Update FileWatcher for script hot-reloading
+    if (GetFileWatcher())
+    {
+        GetFileWatcher()->Update();
+    }
+#endif
+
     if (sEngineState.mSuspended)
     {
         SYS_Update();
@@ -465,6 +517,11 @@ bool Update()
 
 void Shutdown()
 {
+#if EDITOR
+    // Shutdown FileWatcher first
+    DestroyFileWatcher();
+#endif
+
     NetworkManager::Get()->Shutdown();
 
     for (uint32_t i = 0; i < sWorlds.size(); ++i)
@@ -624,6 +681,28 @@ void LoadProject(const std::string& path, bool discoverAssets)
 #endif
 
 #if EDITOR
+    // Start watching the Scripts directory for hot-reloading
+    if (GetFileWatcher() && sEngineState.mProjectDirectory != "")
+    {
+        std::string scriptsDir = sEngineState.mProjectDirectory + "Scripts";
+        
+        // Check if Scripts directory exists by trying to open it as a directory
+        DirEntry dirEntry = {};
+        SYS_OpenDirectory(scriptsDir, dirEntry);
+        bool scriptsExists = dirEntry.mValid;
+        if (dirEntry.mValid)
+        {
+            SYS_CloseDirectory(dirEntry);
+        }
+        
+        if (scriptsExists)
+        {
+            GetFileWatcher()->WatchDirectory(scriptsDir, true);
+        }
+    }
+#endif
+
+#if EDITOR
     GetEditorState()->ReadEditorProjectSave();
     GetEditorState()->LoadStartupScene();
     if (sEngineState.mProjectPath != "")
@@ -734,6 +813,27 @@ void ReloadAllScripts(bool restartComponents)
     LogDebug("--Reloaded All Scripts--");
 
 #endif
+}
+
+void SetScriptHotReloadEnabled(bool enabled)
+{
+#if EDITOR
+    if (GetFileWatcher())
+    {
+        GetFileWatcher()->SetEnabled(enabled);
+    }
+#endif
+}
+
+bool IsScriptHotReloadEnabled()
+{
+#if EDITOR
+    if (GetFileWatcher())
+    {
+        return GetFileWatcher()->IsEnabled();
+    }
+#endif
+    return false;
 }
 
 void SetPaused(bool paused)

--- a/Engine/Source/Engine/Engine.h
+++ b/Engine/Source/Engine/Engine.h
@@ -45,6 +45,11 @@ bool IsGameTickEnabled();
 
 void ReloadAllScripts(bool restartComponents = true);
 
+#if EDITOR
+void SetScriptHotReloadEnabled(bool enabled);
+bool IsScriptHotReloadEnabled();
+#endif
+
 void SetPaused(bool paused);
 bool IsPaused();
 void FrameStep();

--- a/Engine/Source/Engine/FileWatcher.cpp
+++ b/Engine/Source/Engine/FileWatcher.cpp
@@ -1,0 +1,366 @@
+#include "FileWatcher.h"
+#include "Log.h"
+#include "System/System.h"
+#include "EngineTypes.h"
+#include "Engine.h"
+
+#if PLATFORM_WINDOWS
+#include <Windows.h>
+#include <winbase.h>
+#endif
+
+static FileWatcher* sFileWatcher = nullptr;
+
+FileWatcher* GetFileWatcher()
+{
+    return sFileWatcher;
+}
+
+void CreateFileWatcher()
+{
+    if (sFileWatcher == nullptr)
+    {
+        sFileWatcher = new FileWatcher();
+    }
+}
+
+void DestroyFileWatcher()
+{
+    if (sFileWatcher != nullptr)
+    {
+        delete sFileWatcher;
+        sFileWatcher = nullptr;
+    }
+}
+
+FileWatcher::FileWatcher()
+    : mRunning(false)
+    , mEnabled(true)
+#if PLATFORM_WINDOWS
+    , mCompletionPort(INVALID_HANDLE_VALUE)
+#endif
+{
+}
+
+FileWatcher::~FileWatcher()
+{
+    Shutdown();
+}
+
+bool FileWatcher::Initialize()
+{
+#if PLATFORM_WINDOWS
+    // Create I/O completion port
+    mCompletionPort = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
+    if (mCompletionPort == INVALID_HANDLE_VALUE)
+    {
+        LogError("Failed to create I/O completion port for FileWatcher");
+        return false;
+    }
+    
+    mRunning = true;
+    mWatcherThread = std::thread(&FileWatcher::WatcherThread, this);
+    
+    return true;
+#else
+    LogWarning("FileWatcher not implemented for this platform");
+    return false;
+#endif
+}
+
+void FileWatcher::Shutdown()
+{
+    if (mRunning)
+    {
+        mRunning = false;
+        
+#if PLATFORM_WINDOWS
+        // Signal completion port to wake up the thread
+        if (mCompletionPort != INVALID_HANDLE_VALUE)
+        {
+            PostQueuedCompletionStatus(mCompletionPort, 0, 0, NULL);
+        }
+#endif
+
+        if (mWatcherThread.joinable())
+        {
+            mWatcherThread.join();
+        }
+
+#if PLATFORM_WINDOWS
+        // Clean up watch infos
+        for (auto& watchInfo : mWatchInfos)
+        {
+            if (watchInfo.directoryHandle != INVALID_HANDLE_VALUE)
+            {
+                CloseHandle(watchInfo.directoryHandle);
+            }
+        }
+        mWatchInfos.clear();
+        
+        if (mCompletionPort != INVALID_HANDLE_VALUE)
+        {
+            CloseHandle(mCompletionPort);
+            mCompletionPort = INVALID_HANDLE_VALUE;
+        }
+#endif
+    }
+}
+
+bool FileWatcher::WatchDirectory(const std::string& directory, bool recursive)
+{
+#if PLATFORM_WINDOWS
+    if (!mRunning)
+    {
+        LogError("FileWatcher not initialized");
+        return false;
+    }
+    
+    LogDebug("Attempting to watch directory: %s (recursive: %s)", directory.c_str(), recursive ? "true" : "false");
+    
+    // Convert to wide string
+    std::wstring wDirectory = std::wstring(directory.begin(), directory.end());
+    
+    // Open directory handle
+    HANDLE dirHandle = CreateFileW(
+        wDirectory.c_str(),
+        FILE_LIST_DIRECTORY,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+    
+    if (dirHandle == INVALID_HANDLE_VALUE)
+    {
+        LogError("Failed to open directory for watching: %s", directory.c_str());
+        return false;
+    }
+    
+    // Associate with completion port
+    if (CreateIoCompletionPort(dirHandle, mCompletionPort, (ULONG_PTR)mWatchInfos.size(), 0) == NULL)
+    {
+        LogError("Failed to associate directory with completion port: %s", directory.c_str());
+        CloseHandle(dirHandle);
+        return false;
+    }
+    
+    // Create watch info
+    WatchInfo watchInfo = {};
+    watchInfo.directoryHandle = dirHandle;
+    watchInfo.path = directory;
+    watchInfo.recursive = recursive;
+    
+    mWatchInfos.push_back(watchInfo);
+    size_t watchIndex = mWatchInfos.size() - 1;
+    
+    // Start watching
+    DWORD notifyFilter = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION;
+    
+    BOOL result = ReadDirectoryChangesW(
+        dirHandle,
+        mWatchInfos[watchIndex].buffer,
+        sizeof(mWatchInfos[watchIndex].buffer),
+        recursive ? TRUE : FALSE,
+        notifyFilter,
+        NULL,
+        &mWatchInfos[watchIndex].overlapped,
+        NULL
+    );
+    
+    if (!result)
+    {
+        LogError("Failed to start watching directory: %s", directory.c_str());
+        CloseHandle(dirHandle);
+        mWatchInfos.pop_back();
+        return false;
+    }
+    
+    return true;
+#else
+    return false;
+#endif
+}
+
+void FileWatcher::UnwatchDirectory(const std::string& directory)
+{
+#if PLATFORM_WINDOWS
+    for (auto it = mWatchInfos.begin(); it != mWatchInfos.end(); ++it)
+    {
+        if (it->path == directory)
+        {
+            CloseHandle(it->directoryHandle);
+            mWatchInfos.erase(it);
+            break;
+        }
+    }
+#endif
+}
+
+void FileWatcher::SetFileChangeCallback(FileChangeCallback callback)
+{
+    mCallback = callback;
+}
+
+void FileWatcher::Update()
+{
+    if (!mEnabled)
+        return;
+        
+    ProcessEvents();
+}
+
+void FileWatcher::SetEnabled(bool enabled)
+{
+    mEnabled = enabled;
+}
+
+void FileWatcher::WatcherThread()
+{
+#if PLATFORM_WINDOWS
+    while (mRunning)
+    {
+        DWORD bytesTransferred;
+        ULONG_PTR completionKey;
+        LPOVERLAPPED overlapped;
+        
+        BOOL result = GetQueuedCompletionStatus(
+            mCompletionPort,
+            &bytesTransferred,
+            &completionKey,
+            &overlapped,
+            INFINITE
+        );
+        
+        if (!mRunning)
+            break;
+            
+        if (result && overlapped != nullptr)
+        {
+            size_t watchIndex = completionKey;
+            if (watchIndex < mWatchInfos.size())
+            {
+                WatchInfo& watchInfo = mWatchInfos[watchIndex];
+                
+                if (bytesTransferred > 0)
+                {
+                    // Process file change notifications
+                    FILE_NOTIFY_INFORMATION* notify = (FILE_NOTIFY_INFORMATION*)watchInfo.buffer;
+                    
+                    while (true)
+                    {
+                        // Convert filename to narrow string
+                        int filenameLength = notify->FileNameLength / sizeof(WCHAR);
+                        std::wstring wFilename(notify->FileName, filenameLength);
+                        
+                        // Convert wide string to narrow string properly
+                        std::string filename;
+                        if (!wFilename.empty())
+                        {
+                            int size = WideCharToMultiByte(CP_UTF8, 0, wFilename.c_str(), -1, nullptr, 0, nullptr, nullptr);
+                            if (size > 0)
+                            {
+                                filename.resize(size - 1); // -1 to exclude null terminator
+                                WideCharToMultiByte(CP_UTF8, 0, wFilename.c_str(), -1, &filename[0], size, nullptr, nullptr);
+                            }
+                        }
+                        
+                        std::string fullPath = watchInfo.path + "/" + filename;
+                        
+                        // Determine action
+                        FileAction action;
+                        switch (notify->Action)
+                        {
+                            case FILE_ACTION_ADDED:
+                                action = FileAction::Added;
+                                break;
+                            case FILE_ACTION_REMOVED:
+                                action = FileAction::Removed;
+                                break;
+                            case FILE_ACTION_MODIFIED:
+                                action = FileAction::Modified;
+                                break;
+                            case FILE_ACTION_RENAMED_OLD_NAME:
+                            case FILE_ACTION_RENAMED_NEW_NAME:
+                                action = FileAction::Renamed;
+                                break;
+                            default:
+                                action = FileAction::Modified;
+                                break;
+                        }
+                        
+                        // Add to pending events
+                        {
+                            std::lock_guard<std::mutex> lock(mEventsMutex);
+                            FileChangeEvent event;
+                            event.filePath = fullPath;
+                            event.action = action;
+                            mPendingEvents.push_back(event);
+                        }
+                        
+                        if (notify->NextEntryOffset == 0)
+                            break;
+                            
+                        notify = (FILE_NOTIFY_INFORMATION*)((char*)notify + notify->NextEntryOffset);
+                    }
+                }
+                
+                // Continue watching
+                DWORD notifyFilter = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION;
+                
+                ZeroMemory(&watchInfo.overlapped, sizeof(OVERLAPPED));
+                ReadDirectoryChangesW(
+                    watchInfo.directoryHandle,
+                    watchInfo.buffer,
+                    sizeof(watchInfo.buffer),
+                    watchInfo.recursive ? TRUE : FALSE,
+                    notifyFilter,
+                    NULL,
+                    &watchInfo.overlapped,
+                    NULL
+                );
+            }
+        }
+    }
+#endif
+}
+
+void FileWatcher::ProcessEvents()
+{
+    std::vector<FileChangeEvent> eventsToProcess;
+    
+    {
+        std::lock_guard<std::mutex> lock(mEventsMutex);
+        eventsToProcess = std::move(mPendingEvents);
+        mPendingEvents.clear();
+    }
+    
+    for (const auto& event : eventsToProcess)
+    {
+        // Check if this is a script file (.lua extension)
+        if (event.filePath.size() >= 4 && 
+            event.filePath.substr(event.filePath.size() - 4) == ".lua")
+        {
+            // Check for duplicate events by comparing modification times
+            uint64_t currentTime = SYS_GetTimeMicroseconds();
+            auto it = mLastModifyTimes.find(event.filePath);
+            
+            if (it != mLastModifyTimes.end())
+            {
+                // If the last modification was less than 100ms ago, skip this event
+                if (currentTime - it->second < 100000) // 100ms in microseconds
+                {
+                    continue;
+                }
+            }
+            
+            mLastModifyTimes[event.filePath] = currentTime;
+            
+            if (mCallback)
+            {
+                mCallback(event);
+            }
+        }
+    }
+}

--- a/Engine/Source/Engine/FileWatcher.h
+++ b/Engine/Source/Engine/FileWatcher.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "EngineTypes.h"
+#include <string>
+#include <vector>
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <unordered_map>
+#include <mutex>
+
+#if PLATFORM_WINDOWS
+#include <Windows.h>
+#endif
+
+enum class FileAction
+{
+    Added,
+    Modified,
+    Removed,
+    Renamed
+};
+
+struct FileChangeEvent
+{
+    std::string filePath;
+    FileAction action;
+    std::string oldPath; // For rename events
+};
+
+using FileChangeCallback = std::function<void(const FileChangeEvent&)>;
+
+class FileWatcher
+{
+public:
+    FileWatcher();
+    ~FileWatcher();
+
+    // Initialize the file watcher
+    bool Initialize();
+    
+    // Shutdown the file watcher
+    void Shutdown();
+    
+    // Add a directory to watch
+    bool WatchDirectory(const std::string& directory, bool recursive = true);
+    
+    // Remove a directory from watching
+    void UnwatchDirectory(const std::string& directory);
+    
+    // Set callback for file change events
+    void SetFileChangeCallback(FileChangeCallback callback);
+    
+    // Update function to process events (called from main thread)
+    void Update();
+    
+    // Enable/disable the file watcher
+    void SetEnabled(bool enabled);
+    bool IsEnabled() const { return mEnabled; }
+
+private:
+    void WatcherThread();
+    void ProcessEvents();
+    
+#if PLATFORM_WINDOWS
+    struct WatchInfo
+    {
+        HANDLE directoryHandle;
+        OVERLAPPED overlapped;
+        char buffer[8192];
+        std::string path;
+        bool recursive;
+    };
+    
+    std::vector<WatchInfo> mWatchInfos;
+    HANDLE mCompletionPort;
+#endif
+
+    std::thread mWatcherThread;
+    std::atomic<bool> mRunning;
+    std::atomic<bool> mEnabled;
+    
+    FileChangeCallback mCallback;
+    
+    std::vector<FileChangeEvent> mPendingEvents;
+    std::mutex mEventsMutex;
+    
+    // Track last modification times to avoid duplicate events
+    std::unordered_map<std::string, uint64_t> mLastModifyTimes;
+};
+
+// Global file watcher instance
+FileWatcher* GetFileWatcher();
+void CreateFileWatcher();
+void DestroyFileWatcher();


### PR DESCRIPTION
Had to add this since I'm so used to it with other engines + web development 😅 

# Changes

- Added FileWatcher, which can track when a file is added/modified/removed/renamed within a directory
- The Editor will start to watch the `/Scripts` folder of a project whenever the project is loaded
- Whenever a script is modified, it will be reloaded without having to press ALT+R
- When a script is successfully reloaded via hot-reloading, it will search for any nodes in Play Mode with that script and restart it so it instantly receives the changes. The values of any properties are preserved
- Can toggle whether or not the hot-reloading functionality is enabled
<img width="223" height="293" alt="07_21-32-WrithingDingo" src="https://github.com/user-attachments/assets/889c48fb-6295-4789-bc27-0189a832e281" />


https://github.com/user-attachments/assets/4f419a05-756e-4b8c-acdb-282ac51b58da


