### PR TITLE
Add `Property.Create( type, defaultValue )`

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -773,6 +773,7 @@
     <ClCompile Include="Source\LuaBindings\PolyRect_Lua.cpp" />
     <ClCompile Include="Source\LuaBindings\Poly_Lua.cpp" />
     <ClCompile Include="Source\LuaBindings\Primitive3d_Lua.cpp" />
+    <ClCompile Include="Source\LuaBindings\Property_Lua.cpp" />
     <ClCompile Include="Source\LuaBindings\Quad_Lua.cpp" />
     <ClCompile Include="Source\LuaBindings\Rect_Lua.cpp" />
     <ClCompile Include="Source\LuaBindings\Renderer_Lua.cpp" />
@@ -1014,6 +1015,7 @@
     <ClInclude Include="Source\LuaBindings\PolyRect_Lua.h" />
     <ClInclude Include="Source\LuaBindings\Poly_Lua.h" />
     <ClInclude Include="Source\LuaBindings\Primitive3d_Lua.h" />
+    <ClInclude Include="Source\LuaBindings\Property_Lua.h" />
     <ClInclude Include="Source\LuaBindings\Quad_Lua.h" />
     <ClInclude Include="Source\LuaBindings\Rect_Lua.h" />
     <ClInclude Include="Source\LuaBindings\Renderer_Lua.h" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -545,6 +545,9 @@
     <ClCompile Include="Source\LuaBindings\Primitive3d_Lua.cpp">
       <Filter>Source Files\LuaBindings</Filter>
     </ClCompile>
+    <ClCompile Include="Source\LuaBindings\Property_Lua.cpp">
+      <Filter>Source Files\LuaBindings</Filter>
+    </ClCompile>
     <ClCompile Include="Source\LuaBindings\ShadowMesh3d_Lua.cpp">
       <Filter>Source Files\LuaBindings</Filter>
     </ClCompile>
@@ -1249,6 +1252,9 @@
       <Filter>Source Files\LuaBindings</Filter>
     </ClInclude>
     <ClInclude Include="Source\LuaBindings\Primitive3d_Lua.h">
+      <Filter>Source Files\LuaBindings</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\LuaBindings\Property_Lua.h">
       <Filter>Source Files\LuaBindings</Filter>
     </ClInclude>
     <ClInclude Include="Source\LuaBindings\ShadowMesh3d_Lua.h">

--- a/Engine/Source/Editor/EditorImgui.cpp
+++ b/Engine/Source/Editor/EditorImgui.cpp
@@ -887,7 +887,7 @@ static void DrawPropertyList(Object* owner, std::vector<Property>& props)
         // Bools handle name on same line after checkbox
         if (propType != DatumType::Bool || prop.GetCount() > 1)
         {
-            ImGui::Text(prop.mName.c_str());
+            ImGui::Text(prop.mDisplayName.empty() ? prop.mName.c_str() : prop.mDisplayName.c_str());
 
             if (kIndentWidth > 0.0f)
             {
@@ -1006,7 +1006,7 @@ static void DrawPropertyList(Object* owner, std::vector<Property>& props)
                 }
 
                 ImGui::SameLine();
-                ImGui::Text(prop.mName.c_str());
+                ImGui::Text(prop.mDisplayName.empty() ? prop.mName.c_str() : prop.mDisplayName.c_str());
                 break;
             }
             case DatumType::String:

--- a/Engine/Source/Engine/Property.cpp
+++ b/Engine/Source/Engine/Property.cpp
@@ -8,7 +8,7 @@
 
 Property::Property()
 {
-    
+    mDisplayName = mName;  // Default to using name as display name
 }
 
 Property::Property(
@@ -24,6 +24,7 @@ Property::Property(
     Datum(type, owner, data, count, changeHandler)
 {
     mName = name;
+    mDisplayName = name;  // Default to using name as display name
 
     if (extra.IsValid())
     {
@@ -47,6 +48,7 @@ Property::Property(const Property& src) :
     Datum(src)
 {
     mName = src.mName;
+    mDisplayName = src.mDisplayName;
 
     mVector = src.mVector;
     mMinCount = src.mMinCount;
@@ -71,6 +73,9 @@ Property& Property::operator=(const Property& src)
     if (this != &src)
     {
         Datum::operator=(src);
+        mName = src.mName;
+        mDisplayName = src.mDisplayName;
+        // Note: Other members are handled by copy constructor or don't need copying in assignment
     }
 
     return *this;
@@ -80,6 +85,12 @@ void Property::ReadStream(Stream& stream, uint32_t version, bool net, bool exter
 {
     Datum::ReadStream(stream, version, net, external);
     stream.ReadString(mName);
+    
+    // For auto-properties loaded from stream, default display name to name
+    if (mDisplayName.empty())
+    {
+        mDisplayName = mName;
+    }
 
     if (version >= ASSET_VERSION_PROPERTY_EXTRA)
     {

--- a/Engine/Source/Engine/Property.h
+++ b/Engine/Source/Engine/Property.h
@@ -61,6 +61,7 @@ public:
     static const char* sCategory;
 
     std::string mName;
+    std::string mDisplayName;  // Display name for editor UI
     mutable Datum* mExtra = nullptr;
     void* mVector = nullptr;
     uint8_t mMinCount = 0;

--- a/Engine/Source/Engine/Script.cpp
+++ b/Engine/Source/Engine/Script.cpp
@@ -464,6 +464,7 @@ void Script::GatherAutoProperties()
     {
         Property newProp;
         newProp.mName = autoProp.varName; // Use variable name as property name
+        newProp.mDisplayName = autoProp.displayName.empty() ? autoProp.varName : autoProp.displayName;
         newProp.mType = autoProp.type;
         newProp.mOwner = this;
         newProp.mExternal = false;
@@ -471,8 +472,6 @@ void Script::GatherAutoProperties()
         
 #if EDITOR
         newProp.mCategory = "Script";
-        // Note: In the future, you might want to add a separate display name field to Property
-        // For now, the display name is stored in AutoProperty but not used in the final Property
 #endif
         
         // Set the initial value

--- a/Engine/Source/Engine/Script.cpp
+++ b/Engine/Source/Engine/Script.cpp
@@ -13,6 +13,7 @@
 #include "LuaBindings/Network_Lua.h"
 #include "LuaBindings/Widget_Lua.h"
 #include "LuaBindings/World_Lua.h"
+#include "LuaBindings/Property_Lua.h"
 
 DEFINE_OBJECT(Script);
 
@@ -438,6 +439,85 @@ const std::vector<Property>& Script::GetScriptProperties() const
 void Script::SetScriptProperties(const std::vector<Property>& srcProps)
 {
     CopyPropertyValues(mScriptProps, srcProps);
+}
+
+void Script::AddAutoProperty(const std::string& varName, const std::string& displayName, DatumType type, const Datum& defaultValue)
+{
+    AutoProperty autoProp;
+    autoProp.varName = varName;
+    autoProp.displayName = displayName;
+    autoProp.type = type;
+    autoProp.defaultValue = defaultValue;
+    mAutoProperties.push_back(autoProp);
+}
+
+void Script::ClearAutoProperties()
+{
+    mAutoProperties.clear();
+}
+
+void Script::GatherAutoProperties()
+{
+#if LUA_ENABLED
+    // Convert auto properties to regular Properties and add them to mScriptProps
+    for (const AutoProperty& autoProp : mAutoProperties)
+    {
+        Property newProp;
+        newProp.mName = autoProp.varName; // Use variable name as property name
+        newProp.mType = autoProp.type;
+        newProp.mOwner = this;
+        newProp.mExternal = false;
+        newProp.mChangeHandler = HandleScriptPropChange;
+        
+#if EDITOR
+        newProp.mCategory = "Script";
+        // Note: In the future, you might want to add a separate display name field to Property
+        // For now, the display name is stored in AutoProperty but not used in the final Property
+#endif
+        
+        // Set the initial value
+        switch (autoProp.type)
+        {
+        case DatumType::Integer:
+            newProp.PushBack(autoProp.defaultValue.GetInteger());
+            break;
+        case DatumType::Float:
+            newProp.PushBack(autoProp.defaultValue.GetFloat());
+            break;
+        case DatumType::Bool:
+            newProp.PushBack(autoProp.defaultValue.GetBool());
+            break;
+        case DatumType::String:
+            newProp.PushBack(autoProp.defaultValue.GetString());
+            break;
+        case DatumType::Vector2D:
+            newProp.PushBack(autoProp.defaultValue.GetVector2D());
+            break;
+        case DatumType::Vector:
+            newProp.PushBack(autoProp.defaultValue.GetVector());
+            break;
+        case DatumType::Color:
+            newProp.PushBack(autoProp.defaultValue.GetColor());
+            break;
+        case DatumType::Asset:
+            newProp.PushBack(autoProp.defaultValue.GetAsset());
+            break;
+        case DatumType::Node:
+            newProp.PushBack(autoProp.defaultValue.GetNode());
+            break;
+        case DatumType::Byte:
+            newProp.PushBack(autoProp.defaultValue.GetByte());
+            break;
+        case DatumType::Short:
+            newProp.PushBack(autoProp.defaultValue.GetShort());
+            break;
+        default:
+            break;
+        }
+        
+        mScriptProps.push_back(newProp);
+    }
+#endif
 }
 
 void Script::GatherReplicatedData()
@@ -1640,12 +1720,27 @@ void Script::CreateScriptInstance()
 
             SetWorld(mOwner->GetWorld());
 
+            // Set this script as the currently initializing script for future auto property detection
+            Property_Lua::SetCurrentInitializingScript(this);
+            
+            // Clear any existing auto properties
+            ClearAutoProperties();
+
             // Is calling Create() here causing issues? It used to be called after gathering properties.
             // If this causes a problem, consider calling a separate function like PreCreate() or Init() or something.
             CallFunction("Create");
+            
+            // Process any auto properties that were detected (for future implementation)
+            Property_Lua::ProcessPendingAutoProperties(this);
+            
+            // Clear the current initializing script
+            Property_Lua::SetCurrentInitializingScript(nullptr);
 
             UploadScriptProperties();
+            
+            // Gather traditional properties first, then auto properties
             GatherScriptProperties();
+            GatherAutoProperties();
 
             if (GetOwner()->IsReplicated())
             {
@@ -1704,6 +1799,7 @@ void Script::DestroyScriptInstance()
 
         mScriptProps.clear();
         mReplicatedData.clear();
+        mAutoProperties.clear();
 
         mActive = false;
     }

--- a/Engine/Source/Engine/Script.h
+++ b/Engine/Source/Engine/Script.h
@@ -13,6 +13,14 @@
 struct AnimEvent;
 struct Node_Lua;
 
+struct AutoProperty
+{
+    std::string varName;
+    std::string displayName;
+    DatumType type;
+    Datum defaultValue;
+};
+
 typedef std::unordered_map<std::string, ScriptNetFunc> ScriptNetFuncMap;
 
 class Script : public Object
@@ -93,6 +101,11 @@ public:
     const std::vector<Property>& GetScriptProperties() const;
     void SetScriptProperties(const std::vector<Property>& srcProps);
 
+    // Auto property support
+    void AddAutoProperty(const std::string& varName, const std::string& displayName, DatumType type, const Datum& defaultValue);
+    void ClearAutoProperties();
+    void GatherAutoProperties();
+
     static bool OnRepHandler(Datum* datum, uint32_t index, const void* newValue);
 
 protected:
@@ -123,6 +136,7 @@ protected:
     std::string mClassName;
     std::vector<Property> mScriptProps;
     std::vector<ScriptNetDatum> mReplicatedData;
+    std::vector<AutoProperty> mAutoProperties;
     bool mActive = false;
     bool mTickEnabled = false;
     bool mHandleBeginOverlap = false;

--- a/Engine/Source/LuaBindings/LuaBindings.cpp
+++ b/Engine/Source/LuaBindings/LuaBindings.cpp
@@ -55,6 +55,7 @@
 #include "LuaBindings/Signal_Lua.h"
 #include "LuaBindings/Stream_Lua.h"
 #include "LuaBindings/TimerManager_Lua.h"
+#include "LuaBindings/Property_Lua.h"
 
 #include "LuaBindings/Misc_Lua.h"
 
@@ -78,6 +79,7 @@ void BindLuaInterface()
     Stream_Lua::Bind();
     Signal_Lua::Bind();
     TimerManager_Lua::Bind();
+    Property_Lua::Bind();
 
     // Components need to be bound in hierarchy order.
     // Derived classes need to come after parent classes.

--- a/Engine/Source/LuaBindings/Property_Lua.cpp
+++ b/Engine/Source/LuaBindings/Property_Lua.cpp
@@ -1,0 +1,372 @@
+#include "LuaBindings/Property_Lua.h"
+#include "LuaBindings/LuaUtils.h"
+#include "LuaBindings/Vector_Lua.h"
+#include "LuaBindings/Asset_Lua.h"
+#include "LuaBindings/Node_Lua.h"
+#include "Engine/Script.h"
+#include "Log.h"
+#include <vector>
+
+#if LUA_ENABLED
+
+// Static members
+Script* Property_Lua::sCurrentInitializingScript = nullptr;
+std::vector<AutoPropertyInfo> Property_Lua::sPendingAutoProperties;
+
+// Custom userdata type that tracks property information
+struct PropertyTracker
+{
+    DatumType type;
+    Datum value;
+    std::string displayName;
+};
+
+#define PROPERTY_TRACKER_LUA_NAME "PropertyTracker"
+
+int Property_Lua::Create(lua_State* L)
+{
+    int numArgs = lua_gettop(L);
+    
+    if (numArgs < 2)
+    {
+        return 0;
+    }
+    
+    // Get the type (first argument)
+    DatumType type = DatumType::Count;
+    if (lua_isinteger(L, 1))
+    {
+        type = (DatumType)lua_tointeger(L, 1);
+    }
+    else
+    {
+        luaL_error(L, "Property.Create() first argument must be a DatumType");
+        return 0;
+    }
+    
+    // Get the default value (second argument)
+    Datum defaultValue;
+    switch (type)
+    {
+    case DatumType::Integer:
+        if (lua_isinteger(L, 2))
+        {
+            defaultValue = Datum((int32_t)lua_tointeger(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum((int32_t)0);
+        }
+        break;
+    case DatumType::Float:
+        if (lua_isnumber(L, 2))
+        {
+            defaultValue = Datum((float)lua_tonumber(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum(0.0f);
+        }
+        break;
+    case DatumType::Bool:
+        if (lua_isboolean(L, 2))
+        {
+            defaultValue = Datum((bool)lua_toboolean(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum(false);
+        }
+        break;
+    case DatumType::String:
+        if (lua_isstring(L, 2))
+        {
+            defaultValue = Datum(lua_tostring(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum("");
+        }
+        break;
+    case DatumType::Vector2D:
+        if (lua_isuserdata(L, 2))
+        {
+            glm::vec2 vec = CHECK_VECTOR(L, 2);
+            defaultValue = Datum(vec);
+        }
+        else
+        {
+            defaultValue = Datum(glm::vec2(0.0f));
+        }
+        break;
+    case DatumType::Vector:
+        if (lua_isuserdata(L, 2))
+        {
+            glm::vec3 vec = CHECK_VECTOR(L, 2);
+            defaultValue = Datum(vec);
+        }
+        else
+        {
+            defaultValue = Datum(glm::vec3(0.0f));
+        }
+        break;
+    case DatumType::Color:
+        if (lua_isuserdata(L, 2))
+        {
+            glm::vec4 vec = CHECK_VECTOR(L, 2);
+            defaultValue = Datum(vec);
+        }
+        else
+        {
+            defaultValue = Datum(glm::vec4(0.0f));
+        }
+        break;
+    case DatumType::Asset:
+        if (lua_isuserdata(L, 2))
+        {
+            Asset* asset = CHECK_ASSET(L, 2);
+            defaultValue = Datum(asset);
+        }
+        else
+        {
+            defaultValue = Datum((Asset*)nullptr);
+        }
+        break;
+    case DatumType::Node:
+        if (lua_isuserdata(L, 2))
+        {
+            Node* node = CHECK_NODE(L, 2);
+            defaultValue = Datum(node);
+        }
+        else
+        {
+            defaultValue = Datum((Node*)nullptr);
+        }
+        break;
+    case DatumType::Byte:
+        if (lua_isinteger(L, 2))
+        {
+            defaultValue = Datum((uint8_t)lua_tointeger(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum((uint8_t)0);
+        }
+        break;
+    case DatumType::Short:
+        if (lua_isinteger(L, 2))
+        {
+            defaultValue = Datum((int16_t)lua_tointeger(L, 2));
+        }
+        else
+        {
+            defaultValue = Datum((int16_t)0);
+        }
+        break;
+    default:
+        luaL_error(L, "Property.Create() unsupported type: %d", (int)type);
+        return 0;
+    }
+    
+    // Get optional display name (third argument)
+    std::string displayName = "";
+    if (numArgs >= 3 && lua_isstring(L, 3))
+    {
+        displayName = lua_tostring(L, 3);
+    }
+    
+    // Create a PropertyTracker userdata that we can detect later
+    PropertyTracker* tracker = (PropertyTracker*)lua_newuserdata(L, sizeof(PropertyTracker));
+    new (tracker) PropertyTracker();
+    tracker->type = type;
+    tracker->value = defaultValue;
+    tracker->displayName = displayName;
+    
+    // Set the metatable for the PropertyTracker
+    luaL_getmetatable(L, PROPERTY_TRACKER_LUA_NAME);
+    if (lua_isnil(L, -1))
+    {
+        // Create the metatable if it doesn't exist
+        lua_pop(L, 1); // pop nil
+        luaL_newmetatable(L, PROPERTY_TRACKER_LUA_NAME);
+        
+        // Add a __gc metamethod to clean up the tracker
+        lua_pushstring(L, "__gc");
+        lua_pushcfunction(L, [](lua_State* L) -> int {
+            PropertyTracker* tracker = (PropertyTracker*)lua_touserdata(L, 1);
+            tracker->~PropertyTracker();
+            return 0;
+        });
+        lua_rawset(L, -3);
+        
+        // Add __tostring for debugging
+        lua_pushstring(L, "__tostring");
+        lua_pushcfunction(L, [](lua_State* L) -> int {
+            PropertyTracker* tracker = (PropertyTracker*)lua_touserdata(L, 1);
+            std::string str = "PropertyTracker(type=" + std::to_string((int)tracker->type) + ")";
+            lua_pushstring(L, str.c_str());
+            return 1;
+        });
+        lua_rawset(L, -3);
+    }
+    
+    lua_setmetatable(L, -2);
+    
+    return 1;
+}
+
+void Property_Lua::Bind()
+{
+    lua_State* L = GetLua();
+
+    lua_newtable(L);
+    int tableIdx = lua_gettop(L);
+
+    REGISTER_TABLE_FUNC(L, tableIdx, Create);
+
+    lua_setglobal(L, PROPERTY_LUA_NAME);
+
+    OCT_ASSERT(lua_gettop(L) == 0);
+}
+
+Script* Property_Lua::GetCurrentInitializingScript()
+{
+    return sCurrentInitializingScript;
+}
+
+void Property_Lua::SetCurrentInitializingScript(Script* script)
+{
+    sCurrentInitializingScript = script;
+}
+
+void Property_Lua::ProcessPendingAutoProperties(Script* script)
+{
+    if (!script)
+        return;
+        
+    lua_State* L = GetLua();
+    
+    // Get the script instance userdata
+    Node_Lua::Create(L, script->GetOwner());
+    
+    if (lua_isuserdata(L, -1))
+    {
+        int udIdx = lua_gettop(L);
+        
+        // Get the uservalue table (this is where script variables are stored)
+        lua_getuservalue(L, udIdx);
+        if (lua_istable(L, -1))
+        {
+            int uvIdx = lua_gettop(L);
+            
+            // Collect all PropertyTracker objects first to avoid modification during iteration
+            std::vector<std::string> trackerKeys;
+            std::vector<PropertyTracker> trackerData;
+            
+            // Use lua_next to iterate through the uservalue table
+            lua_pushnil(L);  // First key
+            while (lua_next(L, uvIdx) != 0)
+            {
+                // Stack: ... uservalue key value
+                if (lua_isstring(L, -2) && lua_isuserdata(L, -1))
+                {
+                    const char* varName = lua_tostring(L, -2);
+                    
+                    // Check if this is a PropertyTracker
+                    if (luaL_testudata(L, -1, PROPERTY_TRACKER_LUA_NAME))
+                    {
+                        PropertyTracker* tracker = (PropertyTracker*)lua_touserdata(L, -1);
+                        
+                        // Store the key and tracker data
+                        trackerKeys.push_back(varName);
+                        trackerData.push_back(*tracker);
+                    }
+                }
+                
+                lua_pop(L, 1); // pop value, keep key for next iteration
+            }
+            
+            // Now process all the collected PropertyTracker objects
+            for (size_t i = 0; i < trackerKeys.size(); ++i)
+            {
+                const std::string& varName = trackerKeys[i];
+                const PropertyTracker& tracker = trackerData[i];
+                
+                LogDebug("Auto property detected: %s (type: %d)", varName.c_str(), (int)tracker.type);
+                
+                // Add this as an auto property
+                std::string displayName = tracker.displayName.empty() ? varName : tracker.displayName;
+                script->AddAutoProperty(varName, displayName, tracker.type, tracker.value);
+                
+                // Replace the tracker with the actual value
+                switch (tracker.type)
+                {
+                case DatumType::Integer:
+                    lua_pushinteger(L, tracker.value.GetInteger());
+                    break;
+                case DatumType::Float:
+                    lua_pushnumber(L, tracker.value.GetFloat());
+                    break;
+                case DatumType::Bool:
+                    lua_pushboolean(L, tracker.value.GetBool());
+                    break;
+                case DatumType::String:
+                    lua_pushstring(L, tracker.value.GetString().c_str());
+                    break;
+                case DatumType::Vector2D:
+                    Vector_Lua::Create(L, tracker.value.GetVector2D());
+                    break;
+                case DatumType::Vector:
+                    Vector_Lua::Create(L, tracker.value.GetVector());
+                    break;
+                case DatumType::Color:
+                    Vector_Lua::Create(L, tracker.value.GetColor());
+                    break;
+                case DatumType::Asset:
+                    Asset_Lua::Create(L, tracker.value.GetAsset(), true);
+                    break;
+                case DatumType::Node:
+                    Node_Lua::Create(L, tracker.value.GetNode().Get());
+                    break;
+                case DatumType::Byte:
+                    lua_pushinteger(L, (int32_t)tracker.value.GetByte());
+                    break;
+                case DatumType::Short:
+                    lua_pushinteger(L, (int32_t)tracker.value.GetShort());
+                    break;
+                default:
+                    lua_pushnil(L);
+                    break;
+                }
+                
+                // Set the field with the actual value in the uservalue table
+                lua_setfield(L, uvIdx, varName.c_str());
+            }
+            
+            lua_pop(L, 1); // pop uservalue table
+        }
+        else
+        {
+            lua_pop(L, 1); // pop non-table uservalue
+        }
+    }
+    
+    lua_pop(L, 1); // pop userdata
+}
+
+void Property_Lua::ClearPendingProperties()
+{
+    sPendingAutoProperties.clear();
+}
+
+void Property_Lua::AddPendingAutoProperty(const std::string& varName, const std::string& displayName, DatumType type, const Datum& defaultValue)
+{
+    AutoPropertyInfo info;
+    info.varName = varName;
+    info.displayName = displayName;
+    info.type = type;
+    info.defaultValue = defaultValue;
+    sPendingAutoProperties.push_back(info);
+}
+
+#endif

--- a/Engine/Source/LuaBindings/Property_Lua.h
+++ b/Engine/Source/LuaBindings/Property_Lua.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Engine.h"
+#include "Property.h"
+#include "LuaBindings/LuaUtils.h"
+
+#if LUA_ENABLED
+
+#define PROPERTY_LUA_NAME "Property"
+
+struct AutoPropertyInfo
+{
+    std::string varName;
+    std::string displayName;
+    DatumType type;
+    Datum defaultValue;
+};
+
+struct Property_Lua
+{
+    static int Create(lua_State* L);
+    
+    static void Bind();
+    
+    // Static function to get the current script that's being initialized
+    static class Script* GetCurrentInitializingScript();
+    static void SetCurrentInitializingScript(class Script* script);
+    
+    // Function to process pending auto properties
+    static void ProcessPendingAutoProperties(class Script* script);
+    
+    // Clear pending properties
+    static void ClearPendingProperties();
+    
+    // Add a pending auto property
+    static void AddPendingAutoProperty(const std::string& varName, const std::string& displayName, DatumType type, const Datum& defaultValue);
+
+private:
+    static class Script* sCurrentInitializingScript;
+    static std::vector<AutoPropertyInfo> sPendingAutoProperties;
+};
+
+#endif


### PR DESCRIPTION
Currently, you can expose properties by doing the following:
```lua
function MyScript:Create()
    self.myProperty = 123
end

function MyScript:GatherProperties()
    return
    {
        { name = "myProperty", type = DatumType.Float }
    }
end
```

This PR adds an alternate way to define properties directly in the `Create()` function. A third optional argument can be provided to make the display name of the property different from the variable name.

```lua
function MyScript:Create()
    self.gravity = Property.Create(DatumType.Float, 200)
    self.name = Property.Create(DatumType.String, "Michael")
    self.myAsset = Property.Create(DatumType.Asset, nil, "my awesome asset")
end
```

<img width="174" height="123" alt="image" src="https://github.com/user-attachments/assets/ebc42ef3-a996-4c4e-991c-d7c155523b05" />


