### PR TITLE
Editor Asset Autocomplete

### DIFF
--- a/Engine/Source/Editor/EditorImgui.cpp
+++ b/Engine/Source/Editor/EditorImgui.cpp
@@ -1086,15 +1086,6 @@ static void DrawAssetProperty(Property& prop, uint32_t index, Object* owner, Pro
                 {
                     typeMatches = true;
                 }
-                // Make sure we don't match material assets when we want a model
-                else if (assetTypeFilter == StaticMesh::GetStaticType() && 
-                         (stub->mType == MaterialBase::GetStaticType() ||
-                          stub->mType == MaterialInstance::GetStaticType() ||
-                          stub->mType == MaterialLite::GetStaticType() ||
-                          stub->mType == Material::GetStaticType()))
-                {
-                    typeMatches = false; // Explicitly exclude materials when looking for models
-                }
             }
             
             if (stub && typeMatches)

--- a/Engine/Source/Editor/EditorImgui.cpp
+++ b/Engine/Source/Editor/EditorImgui.cpp
@@ -1082,13 +1082,6 @@ static void DrawAssetProperty(Property& prop, uint32_t index, Object* owner, Pro
             if (assetTypeFilter == 0)
             {
                 typeMatches = true; // Accept all types when no filter
-                
-                // But log which assets we're accepting to help debugging
-                if (stub && !(currentTime - lastUpdateTime > 5.0)) // Don't spam the log
-                {
-                    LogDebug("No type filter for %s, showing all asset types including: %s (type: %u)",
-                            sTempString.c_str(), stub->mName.c_str(), stub->mType);
-                }
             }
             else if (stub)
             {

--- a/Engine/Source/Editor/EditorImgui.cpp
+++ b/Engine/Source/Editor/EditorImgui.cpp
@@ -1053,14 +1053,6 @@ static void DrawAssetProperty(Property& prop, uint32_t index, Object* owner, Pro
         assetTypeFilter = (TypeId)prop.mExtra->GetInteger();
     }
 
-    // Make sure we're not defaulting to zero, which means "all types"
-    // If assetTypeFilter is 0, it might be incorrectly set
-    if (assetTypeFilter == 0)
-    {
-        // Log or add debug output
-        LogDebug("Asset property missing type filter: %s", prop.mName.c_str());
-    }
-
     // Get asset suggestions based on type
     static std::vector<std::string> assetSuggestions;
     static TypeId lastAssetTypeFilter = 0;


### PR DESCRIPTION
I found it a bit tedious the way that asset selection works in the editor since I'm not good at remembering the exact names of all my assets, so I added some basic autocomplete functionality to the Asset Property:

https://github.com/user-attachments/assets/9df2eddc-d1f9-4504-a977-a3e94ecb03b9

