### PR TITLE
`Property.CreateArray` to create an array property of a specific type

### DIFF
--- a/Documentation/Lua/Misc/Property.md
+++ b/Documentation/Lua/Misc/Property.md
@@ -23,3 +23,24 @@ Sig: `value = Property.Create(type, defaultValue, displayName)`
  - Arg: `string displayName` *(optional)* Custom name to display in the editor. If not provided, the variable name will be used
  - Ret: `any value` Returns the default value
 ---
+
+### Property.CreateArray
+Creates an array property that will appear in the editor as a list with + and - buttons to add/remove elements. This function should be called during the script's `Create()` method and assigned to a variable on `self`. Each element in the array will have the appropriate UI control based on the specified type.
+
+See [DatumType](./Enums.md#datumtype)
+
+**Basic Usage:**
+```lua
+function MyScript:Create()
+    self.myNumberList = Property.CreateArray(DatumType.Float, {1.0, 2.5, 3.7})
+    self.myAssetList = Property.CreateArray(DatumType.Asset, {})
+    self.nameList = Property.CreateArray(DatumType.String, {"Player1", "Player2"}, "Player Names")
+end
+```
+
+Sig: `value = Property.CreateArray(type, arrayValues, displayName)`
+ - Arg: `DatumType type` The data type of each element in the array (see DatumType enum)
+ - Arg: `table arrayValues` Table containing the initial values for the array
+ - Arg: `string displayName` *(optional)* Custom name to display in the editor. If not provided, the variable name will be used
+ - Ret: `table value` Returns the array of values as a Lua table
+---

--- a/Engine/Source/Engine/Datum.cpp
+++ b/Engine/Source/Engine/Datum.cpp
@@ -1799,7 +1799,6 @@ void Datum::Destroy()
         mData.vp != nullptr)
     {
         OCT_ASSERT(mType != DatumType::Count);
-        OCT_ASSERT(mCount > 0);
 
         for (uint32_t i = 0; i < mCount; i++)
         {

--- a/Engine/Source/Engine/Script.cpp
+++ b/Engine/Source/Engine/Script.cpp
@@ -448,6 +448,19 @@ void Script::AddAutoProperty(const std::string& varName, const std::string& disp
     autoProp.mDisplayName = displayName;
     autoProp.mType = type;
     autoProp.mDefaultValue = defaultValue;
+    autoProp.mIsArray = false;
+    mAutoProperties.push_back(autoProp);
+}
+
+void Script::AddAutoPropertyArray(const std::string& varName, const std::string& displayName, DatumType type, const std::vector<Datum>& arrayValues)
+{
+    AutoProperty autoProp;
+    autoProp.mVarName = varName;
+    autoProp.mDisplayName = displayName;
+    autoProp.mType = type;
+    autoProp.mDefaultValue = arrayValues.empty() ? Datum() : arrayValues[0]; // Default for new entries
+    autoProp.mIsArray = true;
+    autoProp.mArrayValues = arrayValues;
     mAutoProperties.push_back(autoProp);
 }
 
@@ -473,45 +486,94 @@ void Script::GatherAutoProperties()
         newProp.mDisplayName = autoProp.mDisplayName.empty() ? autoProp.mVarName : autoProp.mDisplayName;
         newProp.mCategory = "Script";
 #endif
-        
-        // Set the initial value
-        switch (autoProp.mType)
+
+        if (autoProp.mIsArray)
         {
-        case DatumType::Integer:
-            newProp.PushBack(autoProp.mDefaultValue.GetInteger());
-            break;
-        case DatumType::Float:
-            newProp.PushBack(autoProp.mDefaultValue.GetFloat());
-            break;
-        case DatumType::Bool:
-            newProp.PushBack(autoProp.mDefaultValue.GetBool());
-            break;
-        case DatumType::String:
-            newProp.PushBack(autoProp.mDefaultValue.GetString());
-            break;
-        case DatumType::Vector2D:
-            newProp.PushBack(autoProp.mDefaultValue.GetVector2D());
-            break;
-        case DatumType::Vector:
-            newProp.PushBack(autoProp.mDefaultValue.GetVector());
-            break;
-        case DatumType::Color:
-            newProp.PushBack(autoProp.mDefaultValue.GetColor());
-            break;
-        case DatumType::Asset:
-            newProp.PushBack(autoProp.mDefaultValue.GetAsset());
-            break;
-        case DatumType::Node:
-            newProp.PushBack(autoProp.mDefaultValue.GetNode());
-            break;
-        case DatumType::Byte:
-            newProp.PushBack(autoProp.mDefaultValue.GetByte());
-            break;
-        case DatumType::Short:
-            newProp.PushBack(autoProp.mDefaultValue.GetShort());
-            break;
-        default:
-            break;
+            // For arrays, make it a vector and add all the initial values
+            newProp.MakeVector();
+            for (const Datum& value : autoProp.mArrayValues)
+            {
+                switch (autoProp.mType)
+                {
+                case DatumType::Integer:
+                    newProp.PushBack(value.GetInteger());
+                    break;
+                case DatumType::Float:
+                    newProp.PushBack(value.GetFloat());
+                    break;
+                case DatumType::Bool:
+                    newProp.PushBack(value.GetBool());
+                    break;
+                case DatumType::String:
+                    newProp.PushBack(value.GetString());
+                    break;
+                case DatumType::Vector2D:
+                    newProp.PushBack(value.GetVector2D());
+                    break;
+                case DatumType::Vector:
+                    newProp.PushBack(value.GetVector());
+                    break;
+                case DatumType::Color:
+                    newProp.PushBack(value.GetColor());
+                    break;
+                case DatumType::Asset:
+                    newProp.PushBack(value.GetAsset());
+                    break;
+                case DatumType::Node:
+                    newProp.PushBack(value.GetNode());
+                    break;
+                case DatumType::Byte:
+                    newProp.PushBack(value.GetByte());
+                    break;
+                case DatumType::Short:
+                    newProp.PushBack(value.GetShort());
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+        else
+        {
+            // Set the initial value for non-array properties
+            switch (autoProp.mType)
+            {
+            case DatumType::Integer:
+                newProp.PushBack(autoProp.mDefaultValue.GetInteger());
+                break;
+            case DatumType::Float:
+                newProp.PushBack(autoProp.mDefaultValue.GetFloat());
+                break;
+            case DatumType::Bool:
+                newProp.PushBack(autoProp.mDefaultValue.GetBool());
+                break;
+            case DatumType::String:
+                newProp.PushBack(autoProp.mDefaultValue.GetString());
+                break;
+            case DatumType::Vector2D:
+                newProp.PushBack(autoProp.mDefaultValue.GetVector2D());
+                break;
+            case DatumType::Vector:
+                newProp.PushBack(autoProp.mDefaultValue.GetVector());
+                break;
+            case DatumType::Color:
+                newProp.PushBack(autoProp.mDefaultValue.GetColor());
+                break;
+            case DatumType::Asset:
+                newProp.PushBack(autoProp.mDefaultValue.GetAsset());
+                break;
+            case DatumType::Node:
+                newProp.PushBack(autoProp.mDefaultValue.GetNode());
+                break;
+            case DatumType::Byte:
+                newProp.PushBack(autoProp.mDefaultValue.GetByte());
+                break;
+            case DatumType::Short:
+                newProp.PushBack(autoProp.mDefaultValue.GetShort());
+                break;
+            default:
+                break;
+            }
         }
         
         mScriptProps.push_back(newProp);

--- a/Engine/Source/Engine/Script.h
+++ b/Engine/Source/Engine/Script.h
@@ -19,6 +19,8 @@ struct AutoProperty
     std::string mDisplayName;
     DatumType mType;
     Datum mDefaultValue;
+    bool mIsArray = false;
+    std::vector<Datum> mArrayValues;
 };
 
 typedef std::unordered_map<std::string, ScriptNetFunc> ScriptNetFuncMap;
@@ -103,6 +105,7 @@ public:
 
     // Auto property support
     void AddAutoProperty(const std::string& varName, const std::string& displayName, DatumType type, const Datum& defaultValue);
+    void AddAutoPropertyArray(const std::string& varName, const std::string& displayName, DatumType type, const std::vector<Datum>& arrayValues);
     void ClearAutoProperties();
     void GatherAutoProperties();
 

--- a/Engine/Source/LuaBindings/Property_Lua.cpp
+++ b/Engine/Source/LuaBindings/Property_Lua.cpp
@@ -473,8 +473,6 @@ void Property_Lua::ProcessPendingAutoProperties(Script* script)
                 const std::string& varName = trackerKeys[i];
                 const PropertyTracker& tracker = trackerData[i];
                 
-                LogDebug("Auto property detected: %s (type: %d)", varName.c_str(), (int)tracker.mType);
-                
                 // Add this as an auto property
                 std::string displayName = tracker.mDisplayName.empty() ? varName : tracker.mDisplayName;
                 if (tracker.mIsArray)

--- a/Engine/Source/LuaBindings/Property_Lua.cpp
+++ b/Engine/Source/LuaBindings/Property_Lua.cpp
@@ -19,6 +19,8 @@ struct PropertyTracker
     DatumType mType;
     Datum mValue;
     std::string mDisplayName;
+    bool mIsArray = false;
+    std::vector<Datum> mArrayValues;
 };
 
 #define PROPERTY_TRACKER_LUA_NAME "PropertyTracker"
@@ -215,6 +217,184 @@ int Property_Lua::Create(lua_State* L)
     return 1;
 }
 
+int Property_Lua::CreateArray(lua_State* L)
+{
+    int numArgs = lua_gettop(L);
+    
+    if (numArgs < 2)
+    {
+        return 0;
+    }
+    
+    // Get the type (first argument)
+    DatumType type = DatumType::Count;
+    if (lua_isinteger(L, 1))
+    {
+        type = (DatumType)lua_tointeger(L, 1);
+    }
+    else
+    {
+        luaL_error(L, "Property.CreateArray() first argument must be a DatumType");
+        return 0;
+    }
+    
+    // Get the array values (second argument)
+    std::vector<Datum> arrayValues;
+    if (lua_istable(L, 2))
+    {
+        int len = (int)lua_rawlen(L, 2);
+        for (int i = 1; i <= len; ++i)
+        {
+            lua_rawgeti(L, 2, i);
+            
+            Datum datum;
+            switch (type)
+            {
+            case DatumType::Integer:
+                if (lua_isinteger(L, -1))
+                    datum = Datum((int32_t)lua_tointeger(L, -1));
+                else
+                    datum = Datum((int32_t)0);
+                break;
+            case DatumType::Float:
+                if (lua_isnumber(L, -1))
+                    datum = Datum((float)lua_tonumber(L, -1));
+                else
+                    datum = Datum(0.0f);
+                break;
+            case DatumType::Bool:
+                if (lua_isboolean(L, -1))
+                    datum = Datum((bool)lua_toboolean(L, -1));
+                else
+                    datum = Datum(false);
+                break;
+            case DatumType::String:
+                if (lua_isstring(L, -1))
+                    datum = Datum(lua_tostring(L, -1));
+                else
+                    datum = Datum("");
+                break;
+            case DatumType::Vector2D:
+                if (lua_isuserdata(L, -1))
+                {
+                    glm::vec2 vec = CHECK_VECTOR(L, -1);
+                    datum = Datum(vec);
+                }
+                else
+                    datum = Datum(glm::vec2(0.0f));
+                break;
+            case DatumType::Vector:
+                if (lua_isuserdata(L, -1))
+                {
+                    glm::vec3 vec = CHECK_VECTOR(L, -1);
+                    datum = Datum(vec);
+                }
+                else
+                    datum = Datum(glm::vec3(0.0f));
+                break;
+            case DatumType::Color:
+                if (lua_isuserdata(L, -1))
+                {
+                    glm::vec4 vec = CHECK_VECTOR(L, -1);
+                    datum = Datum(vec);
+                }
+                else
+                    datum = Datum(glm::vec4(0.0f));
+                break;
+            case DatumType::Asset:
+                if (lua_isuserdata(L, -1))
+                {
+                    Asset* asset = CHECK_ASSET(L, -1);
+                    datum = Datum(asset);
+                }
+                else
+                    datum = Datum((Asset*)nullptr);
+                break;
+            case DatumType::Node:
+                if (lua_isuserdata(L, -1))
+                {
+                    Node* node = CHECK_NODE(L, -1);
+                    datum = Datum(node);
+                }
+                else
+                    datum = Datum((Node*)nullptr);
+                break;
+            case DatumType::Byte:
+                if (lua_isinteger(L, -1))
+                    datum = Datum((uint8_t)lua_tointeger(L, -1));
+                else
+                    datum = Datum((uint8_t)0);
+                break;
+            case DatumType::Short:
+                if (lua_isinteger(L, -1))
+                    datum = Datum((int16_t)lua_tointeger(L, -1));
+                else
+                    datum = Datum((int16_t)0);
+                break;
+            default:
+                luaL_error(L, "Property.CreateArray() unsupported type: %d", (int)type);
+                return 0;
+            }
+            
+            arrayValues.push_back(datum);
+            lua_pop(L, 1);
+        }
+    }
+    else
+    {
+        luaL_error(L, "Property.CreateArray() second argument must be a table");
+        return 0;
+    }
+    
+    // Get optional display name (third argument)
+    std::string displayName = "";
+    if (numArgs >= 3 && lua_isstring(L, 3))
+    {
+        displayName = lua_tostring(L, 3);
+    }
+    
+    // Create a PropertyTracker userdata for arrays
+    PropertyTracker* tracker = (PropertyTracker*)lua_newuserdata(L, sizeof(PropertyTracker));
+    new (tracker) PropertyTracker();
+    tracker->mType = type;
+    tracker->mValue = arrayValues.empty() ? Datum() : arrayValues[0]; // Default value for new entries
+    tracker->mDisplayName = displayName;
+    tracker->mIsArray = true;
+    tracker->mArrayValues = arrayValues;
+    
+    // Set the metatable for the PropertyTracker
+    luaL_getmetatable(L, PROPERTY_TRACKER_LUA_NAME);
+    if (lua_isnil(L, -1))
+    {
+        // Create the metatable if it doesn't exist
+        lua_pop(L, 1); // pop nil
+        luaL_newmetatable(L, PROPERTY_TRACKER_LUA_NAME);
+        
+        // Add a __gc metamethod to clean up the tracker
+        lua_pushstring(L, "__gc");
+        lua_pushcfunction(L, [](lua_State* L) -> int {
+            PropertyTracker* tracker = (PropertyTracker*)lua_touserdata(L, 1);
+            tracker->~PropertyTracker();
+            return 0;
+        });
+        lua_rawset(L, -3);
+        
+        // Add __tostring for debugging
+        lua_pushstring(L, "__tostring");
+        lua_pushcfunction(L, [](lua_State* L) -> int {
+            PropertyTracker* tracker = (PropertyTracker*)lua_touserdata(L, 1);
+            std::string str = "PropertyTracker(type=" + std::to_string((int)tracker->mType) + ", isArray=" + (tracker->mIsArray ? "true" : "false") + ")";
+            lua_pushstring(L, str.c_str());
+            return 1;
+        });
+        lua_rawset(L, -3);
+    }
+    
+    lua_setmetatable(L, -2);
+    
+    return 1;
+}
+
 void Property_Lua::Bind()
 {
     lua_State* L = GetLua();
@@ -223,6 +403,7 @@ void Property_Lua::Bind()
     int tableIdx = lua_gettop(L);
 
     REGISTER_TABLE_FUNC(L, tableIdx, Create);
+    REGISTER_TABLE_FUNC(L, tableIdx, CreateArray);
 
     lua_setglobal(L, PROPERTY_LUA_NAME);
 
@@ -296,47 +477,107 @@ void Property_Lua::ProcessPendingAutoProperties(Script* script)
                 
                 // Add this as an auto property
                 std::string displayName = tracker.mDisplayName.empty() ? varName : tracker.mDisplayName;
-                script->AddAutoProperty(varName, displayName, tracker.mType, tracker.mValue);
+                if (tracker.mIsArray)
+                {
+                    script->AddAutoPropertyArray(varName, displayName, tracker.mType, tracker.mArrayValues);
+                }
+                else
+                {
+                    script->AddAutoProperty(varName, displayName, tracker.mType, tracker.mValue);
+                }
                 
                 // Replace the tracker with the actual value
-                switch (tracker.mType)
+                if (tracker.mIsArray)
                 {
-                case DatumType::Integer:
-                    lua_pushinteger(L, tracker.mValue.GetInteger());
-                    break;
-                case DatumType::Float:
-                    lua_pushnumber(L, tracker.mValue.GetFloat());
-                    break;
-                case DatumType::Bool:
-                    lua_pushboolean(L, tracker.mValue.GetBool());
-                    break;
-                case DatumType::String:
-                    lua_pushstring(L, tracker.mValue.GetString().c_str());
-                    break;
-                case DatumType::Vector2D:
-                    Vector_Lua::Create(L, tracker.mValue.GetVector2D());
-                    break;
-                case DatumType::Vector:
-                    Vector_Lua::Create(L, tracker.mValue.GetVector());
-                    break;
-                case DatumType::Color:
-                    Vector_Lua::Create(L, tracker.mValue.GetColor());
-                    break;
-                case DatumType::Asset:
-                    Asset_Lua::Create(L, tracker.mValue.GetAsset(), true);
-                    break;
-                case DatumType::Node:
-                    Node_Lua::Create(L, tracker.mValue.GetNode().Get());
-                    break;
-                case DatumType::Byte:
-                    lua_pushinteger(L, (int32_t)tracker.mValue.GetByte());
-                    break;
-                case DatumType::Short:
-                    lua_pushinteger(L, (int32_t)tracker.mValue.GetShort());
-                    break;
-                default:
-                    lua_pushnil(L);
-                    break;
+                    // Create a Lua table for array values
+                    lua_newtable(L);
+                    for (size_t j = 0; j < tracker.mArrayValues.size(); ++j)
+                    {
+                        const Datum& value = tracker.mArrayValues[j];
+                        switch (tracker.mType)
+                        {
+                        case DatumType::Integer:
+                            lua_pushinteger(L, value.GetInteger());
+                            break;
+                        case DatumType::Float:
+                            lua_pushnumber(L, value.GetFloat());
+                            break;
+                        case DatumType::Bool:
+                            lua_pushboolean(L, value.GetBool());
+                            break;
+                        case DatumType::String:
+                            lua_pushstring(L, value.GetString().c_str());
+                            break;
+                        case DatumType::Vector2D:
+                            Vector_Lua::Create(L, value.GetVector2D());
+                            break;
+                        case DatumType::Vector:
+                            Vector_Lua::Create(L, value.GetVector());
+                            break;
+                        case DatumType::Color:
+                            Vector_Lua::Create(L, value.GetColor());
+                            break;
+                        case DatumType::Asset:
+                            Asset_Lua::Create(L, value.GetAsset(), true);
+                            break;
+                        case DatumType::Node:
+                            Node_Lua::Create(L, value.GetNode().Get());
+                            break;
+                        case DatumType::Byte:
+                            lua_pushinteger(L, (int32_t)value.GetByte());
+                            break;
+                        case DatumType::Short:
+                            lua_pushinteger(L, (int32_t)value.GetShort());
+                            break;
+                        default:
+                            lua_pushnil(L);
+                            break;
+                        }
+                        lua_rawseti(L, -2, (int)(j + 1)); // Lua tables are 1-indexed
+                    }
+                }
+                else
+                {
+                    // Single value
+                    switch (tracker.mType)
+                    {
+                    case DatumType::Integer:
+                        lua_pushinteger(L, tracker.mValue.GetInteger());
+                        break;
+                    case DatumType::Float:
+                        lua_pushnumber(L, tracker.mValue.GetFloat());
+                        break;
+                    case DatumType::Bool:
+                        lua_pushboolean(L, tracker.mValue.GetBool());
+                        break;
+                    case DatumType::String:
+                        lua_pushstring(L, tracker.mValue.GetString().c_str());
+                        break;
+                    case DatumType::Vector2D:
+                        Vector_Lua::Create(L, tracker.mValue.GetVector2D());
+                        break;
+                    case DatumType::Vector:
+                        Vector_Lua::Create(L, tracker.mValue.GetVector());
+                        break;
+                    case DatumType::Color:
+                        Vector_Lua::Create(L, tracker.mValue.GetColor());
+                        break;
+                    case DatumType::Asset:
+                        Asset_Lua::Create(L, tracker.mValue.GetAsset(), true);
+                        break;
+                    case DatumType::Node:
+                        Node_Lua::Create(L, tracker.mValue.GetNode().Get());
+                        break;
+                    case DatumType::Byte:
+                        lua_pushinteger(L, (int32_t)tracker.mValue.GetByte());
+                        break;
+                    case DatumType::Short:
+                        lua_pushinteger(L, (int32_t)tracker.mValue.GetShort());
+                        break;
+                    default:
+                        lua_pushnil(L);
+                        break;
+                    }
                 }
                 
                 // Set the field with the actual value in the uservalue table

--- a/Engine/Source/LuaBindings/Property_Lua.h
+++ b/Engine/Source/LuaBindings/Property_Lua.h
@@ -19,6 +19,7 @@ struct AutoPropertyInfo
 struct Property_Lua
 {
     static int Create(lua_State* L);
+    static int CreateArray(lua_State* L);
     
     static void Bind();
     


### PR DESCRIPTION
# Changes

- Adds `Property.CreateArray( type, defaultValue, [displayName] )`
- If a property is an array, then the Editor will show +/- buttons to add and remove entries from the array
 
<img width="266" height="144" alt="image" src="https://github.com/user-attachments/assets/3244120c-c2e0-4654-aeec-080168a25fcb" />

# Example

https://github.com/user-attachments/assets/7ab035c7-7407-4d8a-9a76-5e31e00362c9

```lua
function TestScript:Create()
    self.modelList = Property.CreateArray(DatumType.Asset, {}, "Potential Models")
    self.colorList = Property.CreateArray(DatumType.Color, {Vec(1,0,0, 1), Vec(0,1,0,1), Vec(0,0,1,1)}, "Potential Colors")
end

function TestScript:Start()
    if self:CheckType("StaticMesh3D") then
        local randomIndex = math.random(1, #self.modelList)
        self:SetStaticMesh(self.modelList[randomIndex])
        local randomColorIndex = math.random(1, #self.colorList)
        local newMaterial = MaterialLite.Create(self:GetMaterial())
        newMaterial:SetColor(self.colorList[randomColorIndex])
        self:SetMaterialOverride(newMaterial)
    end
end
```