### PR TITLE
Fix signedness comparison warnings in SceneComponent

### DIFF
--- a/Engine/Source/Engine/Assets/Scene.cpp
+++ b/Engine/Source/Engine/Assets/Scene.cpp
@@ -351,9 +351,9 @@ NodePtr Scene::Instantiate()
         for (uint32_t i = 0; i < mNodeDefs.size(); ++i)
         {
             NodePtr nodePtr;
-            NodePtr parent = (i > 0 && nodeList.size() > mNodeDefs[i].mParentIndex) ? nodeList[mNodeDefs[i].mParentIndex] : nullptr;
+            NodePtr parent = (i > 0 && int32_t(nodeList.size()) > mNodeDefs[i].mParentIndex) ? nodeList[mNodeDefs[i].mParentIndex] : nullptr;
 
-            if (i > 0 && nodeList.size() <= mNodeDefs[i].mParentIndex)
+            if (i > 0 && int32_t(nodeList.size()) <= mNodeDefs[i].mParentIndex)
             {
                 LogError("Out-of-order parent for node: %s", mNodeDefs[i].mName.c_str());
                 parent = nodeList[0];

--- a/Engine/Source/Engine/Assets/Scene.cpp
+++ b/Engine/Source/Engine/Assets/Scene.cpp
@@ -351,9 +351,9 @@ NodePtr Scene::Instantiate()
         for (uint32_t i = 0; i < mNodeDefs.size(); ++i)
         {
             NodePtr nodePtr;
-            NodePtr parent = (i > 0 && int32_t(nodeList.size()) > mNodeDefs[i].mParentIndex) ? nodeList[mNodeDefs[i].mParentIndex] : nullptr;
+            NodePtr parent = (i > 0 && mNodeDefs[i].mParentIndex >= 0 && mNodeDefs[i].mParentIndex < static_cast<int32_t>(nodeList.size())) ? nodeList[mNodeDefs[i].mParentIndex] : nullptr;
 
-            if (i > 0 && int32_t(nodeList.size()) <= mNodeDefs[i].mParentIndex)
+            if (i > 0 && (mNodeDefs[i].mParentIndex < 0 || mNodeDefs[i].mParentIndex >= static_cast<int32_t>(nodeList.size())))
             {
                 LogError("Out-of-order parent for node: %s", mNodeDefs[i].mName.c_str());
                 parent = nodeList[0];


### PR DESCRIPTION
Compiling with -Wsign-compare produces warnings in SceneComponent where nodeList.size() (unsigned) is compared with int32_t loop variables. The fix follows the existing codebase pattern of casting container sizes to int32_t at the comparison site.

Fixes #61