### PR TITLE
Add .gitattributes to enforce LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts always use LF line endings, even on Windows
+*.sh text eol=lf


### PR DESCRIPTION
Fixes #68

## Summary

- Adds a `.gitattributes` file that forces `*.sh` files to use LF line endings, even when cloned on Windows with `core.autocrlf=true`.
- Without this, shell scripts checked out with CRLF line endings fail to execute on Unix-like systems.

## Test plan

- Clone the repo on Windows with `core.autocrlf=true` and verify `.sh` files have LF endings
- Verify existing `.sh` files are normalized on next checkout