### PR TITLE
adding in caps lock and finishing numpad support for windows/linux

### DIFF
--- a/Engine/Source/Editor/imgui_impl_xcb.cpp
+++ b/Engine/Source/Editor/imgui_impl_xcb.cpp
@@ -152,6 +152,7 @@ static ImGuiKey ImGui_ImplXcb_VirtualKeyToImGuiKey(xcb_keycode_t keyCode)
         case KEY_NUMPAD7: return ImGuiKey_Keypad7;
         case KEY_NUMPAD8: return ImGuiKey_Keypad8;
         case KEY_NUMPAD9: return ImGuiKey_Keypad9;
+        case KEY_NUMPADENTER: return ImGuiKey_Enter;
         case KEY_DECIMAL: return ImGuiKey_KeypadDecimal;
         //case VK_DIVIDE: return ImGuiKey_KeypadDivide;
         //case VK_MULTIPLY: return ImGuiKey_KeypadMultiply;

--- a/Engine/Source/Engine/InputDevices.h
+++ b/Engine/Source/Engine/InputDevices.h
@@ -12,6 +12,7 @@ bool IsKeyJustUp(int32_t key);
 
 bool IsControlDown();
 bool IsShiftDown();
+bool IsCapsOn();
 bool IsAltDown();
 void ClearControlDown();
 void ClearShiftDown();

--- a/Engine/Source/Engine/InputDevices.h
+++ b/Engine/Source/Engine/InputDevices.h
@@ -12,7 +12,6 @@ bool IsKeyJustUp(int32_t key);
 
 bool IsControlDown();
 bool IsShiftDown();
-bool IsCapsOn();
 bool IsAltDown();
 void ClearControlDown();
 void ClearShiftDown();

--- a/Engine/Source/Engine/Utilities.cpp
+++ b/Engine/Source/Engine/Utilities.cpp
@@ -491,14 +491,16 @@ uint8_t ConvertKeyCodeToChar(uint8_t keyCode, bool shiftDown)
 {
     uint8_t retChar = 0;
     retChar = INP_ConvertKeyCodeToChar(keyCode);
+    InputState& input = GetEngineState()->mInput;
+    bool capsLocked = input.mCapsLocked;
 
     if (retChar >= 'A' &&
         retChar <= 'Z' &&
-        !shiftDown)
+        !shiftDown &&
+        !capsLocked)
     {
-        // If not shifted, make the character lower-case.
-        // TODO: handle caps lock state.
         retChar += 32;
+
     }
     else if (shiftDown)
     {
@@ -525,6 +527,12 @@ uint8_t ConvertKeyCodeToChar(uint8_t keyCode, bool shiftDown)
         case ',': retChar = '<'; break;
         case '.': retChar = '>'; break;
         case '/': retChar = '?'; break;
+        }
+        if (retChar >= 'A' &&
+            retChar <= 'Z' &&
+            capsLocked)
+        {
+            retChar += 32;
         }
     }
 

--- a/Engine/Source/Engine/Utilities.cpp
+++ b/Engine/Source/Engine/Utilities.cpp
@@ -500,7 +500,6 @@ uint8_t ConvertKeyCodeToChar(uint8_t keyCode, bool shiftDown)
         !capsLocked)
     {
         retChar += 32;
-
     }
     else if (shiftDown)
     {

--- a/Engine/Source/Input/Input.cpp
+++ b/Engine/Source/Input/Input.cpp
@@ -157,6 +157,11 @@ char INP_ConvertKeyCodeToChar(int32_t key)
     case KEY_NUMPAD7: retChar = '7'; break;
     case KEY_NUMPAD8: retChar = '8'; break;
     case KEY_NUMPAD9: retChar = '9'; break;
+    case KEY_NUMPADENTER: retChar = '\n'; break;
+    case KEY_NUMPADPLUS: retChar = '+'; break;
+    case KEY_NUMPADMINUS: retChar = '-'; break;
+    case KEY_NUMPADMULT: retChar = '*'; break;
+    case KEY_NUMPADDIV: retChar = '/'; break;
 
     case KEY_PERIOD: retChar = '.'; break;
     case KEY_COMMA: retChar = ','; break;
@@ -170,6 +175,13 @@ char INP_ConvertKeyCodeToChar(int32_t key)
     case KEY_RIGHT_BRACKET: retChar = ']'; break;
     case KEY_QUOTE: retChar = '\''; break;
     case KEY_DECIMAL: retChar = '.'; break;
+
+
+    case KEY_CAPS:{
+        InputState& input = GetEngineState()->mInput;
+        input.mCapsLocked = !input.mCapsLocked;
+        break;
+    }
 
     default: break;
     }

--- a/Engine/Source/Input/InputTypes.h
+++ b/Engine/Source/Input/InputTypes.h
@@ -120,6 +120,7 @@ struct InputState
     bool mCursorLocked = false;
     bool mCursorTrapped = false;
     bool mCursorShown = true;
+    bool mCapsLocked = false;
 
 #if PLATFORM_WINDOWS
     XINPUT_STATE mXinputStates[INPUT_MAX_GAMEPADS] = { };
@@ -207,6 +208,11 @@ enum KeyCode
     KEY_NUMPAD7 = 103,
     KEY_NUMPAD8 = 104,
     KEY_NUMPAD9 = 105,
+    KEY_NUMPADENTER = 108,
+    KEY_NUMPADPLUS = 107,
+    KEY_NUMPADMINUS = 109,
+    KEY_NUMPADMULT = 106,
+    KEY_NUMPADDIV = 111,
 
     KEY_F1 = 112,
     KEY_F2 = 113,
@@ -234,7 +240,9 @@ enum KeyCode
     KEY_RIGHT_BRACKET = 0xDD,
     KEY_QUOTE = 0xDE,
 
-    KEY_DECIMAL = 0x6E
+    KEY_DECIMAL = 0x6E,
+
+    KEY_CAPS = 20
 };
 
 #elif PLATFORM_ANDROID
@@ -573,6 +581,11 @@ enum KeyCode
     KEY_NUMPAD7 = 79,
     KEY_NUMPAD8 = 80,
     KEY_NUMPAD9 = 81,
+    KEY_NUMPADENTER = 104,
+    KEY_NUMPADPLUS = 86,
+    KEY_NUMPADMINUS = 82,
+    KEY_NUMPADMULT = 63,
+    KEY_NUMPADDIV = 106,
 
     KEY_F1 = 67,
     KEY_F2 = 68,
@@ -600,7 +613,9 @@ enum KeyCode
     KEY_RIGHT_BRACKET = 35,
     KEY_QUOTE = 48,
 
-    KEY_DECIMAL = 91
+    KEY_DECIMAL = 91,
+
+    KEY_CAPS = 66
 };
 
 #else // All other platforms


### PR DESCRIPTION
added in a false by default boolean to inputstate that tracks the capslock status inside the engine. this does not ask the system for a caps state, so if its on prior to opening the engine, the engine will not recognize this.
also adds support for the math and enter keys on the numpad.